### PR TITLE
Fix check if img_id is empty or non-empty (use -z instead of ! -n)

### DIFF
--- a/libraries/docker/steps/build.groovy
+++ b/libraries/docker/steps/build.groovy
@@ -14,7 +14,7 @@ void call(){
           for i in \$base_images
           do
             img_id=`docker images -q \$i`
-            if [[ ! -n \$img_id ]]; then
+            if [[ -z \$img_id ]]; then
               docker pull \$i
             fi
           done


### PR DESCRIPTION
Example: https://jenkins.skymavis.one/view/origin/job/origin-reward/view/change-requests/job/PR-130/11/console